### PR TITLE
Add missing light stemmer to Lucene API example, consistent with solr and ES

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Analyzer analyzer = CustomAnalyzer.builder(Paths.get("/path/to/german-decompound
                        "onlyLongestMatch", "true",
                        "minSubwordSize", "4")
        .addTokenFilter(GermanNormalizationFilterFactory.NAME)
+       .addTokenFilter(GermanLightStemFilterFactory.NAME)
        .build();
 ```
 


### PR DESCRIPTION
Oops, I forgot the very last tokenfilter in the chain!